### PR TITLE
Better nestedSort

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,8 +268,8 @@ const nestedSort = (a, b) => {
     if (!ac && !bc) return 0;
     if (ac && !bc) return 1;
     if (!ac && bc) return -1;
-    if (ac < bc) return 1;
-    if (ac > bc) return -1;
+    if (ac > bc) return 1;
+    if (ac < bc) return -1;
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -262,16 +262,15 @@ const proxyCompare = (a, b, locations) => {
 };
 
 const nestedSort = (a, b) => {
-  const al = a.length;
-  const bl = b.length;
-
-  if (al < bl) {
-    return b.indexOf(a) === 0 ? -1 : 1;
+  for (let i = 0; ; ++i) {
+    const ac = a.charCodeAt(i);
+    const bc = b.charCodeAt(i);
+    if (!ac && !bc) return 0;
+    if (ac && !bc) return 1;
+    if (!ac && bc) return -1;
+    if (ac < bc) return 1;
+    if (ac > bc) return -1;
   }
-  if (al > bl) {
-    return a.indexOf(b) === 0 ? -1 : 1;
-  }
-  return 0;
 };
 
 const sortedLocations = locations => [...locations].sort(nestedSort);

--- a/src/weakMemoize.js
+++ b/src/weakMemoize.js
@@ -1,4 +1,6 @@
 export const weakMemoizeArray = fn => {
+  return arg => fn(arg); // for benchmark
+
   let cache = new WeakMap();
   return arg => {
     if (cache.has(arg)) {


### PR DESCRIPTION
I guess nestedSort was not implemented as expected.
```javascript
> [".e",".e.a",".e.a.b",".a",'.b'].sort(old_nestedSort)
[ '.e', '.a', '.b', '.e.a', '.e.a.b' ]
> [".e",".e.a",".e.a.b",".a",'.b'].sort(new_nestedSort)
[ '.a', '.b', '.e', '.e.a', '.e.a.b' ]
```

weakMemoization should be disabled for benchmarking nestedSort.

old:
`proxyShallowEqual x 390,346 ops/sec ±1.98% (87 runs sampled)`
new:
`proxyShallowEqual x 424,974 ops/sec ±0.72% (89 runs sampled)`
