### PR TITLE
Avoid shouldInstrument ReferenceError on ES6 types

### DIFF
--- a/src/shouldInstrument.js
+++ b/src/shouldInstrument.js
@@ -1,4 +1,4 @@
-// copy-paste from https://github.com/nx-js/observer-util/blob/master/src/builtIns/index.js
+// Based on https://github.com/nx-js/observer-util/blob/master/src/builtIns/index.js
 
 // built-in object can not be wrapped by Proxies, or, to be clear - unfreezed
 // their methods expect the object instance as the 'this' instead of the Proxy wrapper
@@ -15,37 +15,34 @@ const collectionHandlers = {
   [Symbol.iterator]: true
 };
 
-const handlers = new Map([
-  [Map, collectionHandlers],
-  [Set, collectionHandlers],
-  [WeakMap, collectionHandlers],
-  [WeakSet, collectionHandlers],
-  [Object, false],
-  [Array, false],
-  [Int8Array, false],
-  [Uint8Array, false],
-  [Uint8ClampedArray, false],
-  [Int16Array, false],
-  [Uint16Array, false],
-  [Int32Array, false],
-  [Uint32Array, false],
-  [Float32Array, false],
-  [Float64Array, false]
-]);
+const handlers = {
+  Map: collectionHandlers,
+  Set: collectionHandlers,
+  WeakMap: collectionHandlers,
+  WeakSet: collectionHandlers,
+  Object: false,
+  Array: false,
+  Int8Array: false,
+  Uint8Array: false,
+  Uint8ClampedArray: false,
+  Int16Array: false,
+  Uint16Array: false,
+  Int32Array: false,
+  Uint32Array: false,
+  Float32Array: false,
+  Float64Array: false
+};
 
-
-// eslint-disable-next-line
 const globalObj = typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : {};
 
 export function shouldInstrument({constructor}) {
+  const name = constructor.name;
   const isBuiltIn = (
     typeof constructor === 'function' &&
-    constructor.name in globalObj &&
-    globalObj[constructor.name] === constructor
+    name in globalObj &&
+    globalObj[name] === constructor
   );
-  return !isBuiltIn || handlers.has(constructor);
+  return !isBuiltIn || handlers.hasOwnProperty(name);
 }
 
-export const getCollectionHandlers = ({constructor}) => (
-  handlers.get(constructor)
-)
+export const getCollectionHandlers = ({constructor}) => handlers[constructor.name];


### PR DESCRIPTION
To check for builtin types, the `shouldInstrument` file creates a map with various constructors as the keys. However, as `WeakSet` is not used, there's no guarantee it's been polyfilled in for browsers that lack support like IE11, which leads to a runtime `ReferenceError` when `proxyequal` is imported.

Instead key on the constructor name, which gracefully handles cases where the browser does not have one of the types that need special handling.

Example load failure on IE11 with `2.0.6` currently:
```
"ReferenceError: 'WeakSet' is undefined
   at Anonymous function (eval code:26:1)
   at eval code (eval code:1:29)
   at ./node_modules/proxyequal/lib/shouldInstrument.js (...:355:1)
   at __webpack_require__ (...:767:12)
```